### PR TITLE
Allow resume when downloading crash. aiofile depency removed

### DIFF
--- a/pytube/request.py
+++ b/pytube/request.py
@@ -175,7 +175,7 @@ async def stream(
     file_size: int = default_range_size if stream_filesize == 0 else stream_filesize # fake filesize to start otherwise use existing filesize
     downloaded = current_downloaded 
     while downloaded < file_size:
-        print("Im not here hahah ")
+        # print("Im not here hahah ")
         stop_pos = min(downloaded + default_range_size, file_size) - 1
         range_header = f"bytes={downloaded}-"
         tries = 0
@@ -212,7 +212,7 @@ async def stream(
         if file_size == default_range_size:
             try:
                 content_range = response.headers["Content-Range"]
-                print("voici le content range:{}".format(content_range))
+                # print("voici le content range:{}".format(content_range))
                 file_size = int(content_range.split("/")[1])
             except (KeyError, IndexError, ValueError) as e:
                 logger.error(e)

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -17,9 +17,9 @@ from urllib.error import HTTPError
 from urllib.parse import parse_qs
 from aiohttp import ClientSession
 from async_property import async_property
-import aiofiles as aiofs
+# import aiofiles as aiofs
 import aiofile as aiof
-from aiofiles.threadpool.binary import AsyncFileIO
+# from aiofiles.threadpool.binary import AsyncFileIO
 from pytube import extract
 from pytube import request
 from pytube.helpers import safe_filename
@@ -254,28 +254,37 @@ class Stream:
             output_path=output_path,
             filename_prefix=filename_prefix,
         )
-
-        if skip_existing and await self.exists_at_path(file_path):
+        if skip_existing and  await self.exists_at_path(file_path):
             logger.debug(f'file {file_path} already exists, skipping')
             await self.on_complete(file_path)
             return file_path
 
         bytes_remaining = (await self.filesize)
         logger.debug(f'downloading ({(await self.filesize)} total bytes) file to {file_path}')
-
-        with open(file_path, "wb") as fh:
+        # async_open allow us to open and write on many files concurently
+        async with aiof.async_open(file_path, "ab+") as fh:
+            """ 'current_downloaded' help us to indicate to the server that we have already downloaded part of the file and  we just want to continue downloading from there
+            """ 
+            current_downloaded = fh.tell() # since we are opening file with 'ab' mode file_handler will give filesize in bytes
             try:
+               
                 async for chunk in request.stream(
                     self.url,
                     self._session,
                     timeout=timeout,
-                    max_retries=max_retries
+                    max_retries=max_retries,
+                    current_downloaded=current_downloaded,
+                    stream_filesize= bytes_remaining
                 ):
-                    # reduce the (bytes) remainder by the length of the chunk.
-                    bytes_remaining -= len(chunk)
-                    # send to the on_progress callback.
-                    await self.on_progress(chunk, fh, bytes_remaining)
+                    # # reduce the (bytes) remainder by the length of the chunk.
+                    # bytes_remaining = -len(chunk)
+                    
+                    # send to the on_progress callback with the current downloaded file to easily compute percentage in callback
+                    bytes_remaining = fh.tell()
+                    await self.on_progress(chunk, fh,bytes_remaining,)
+                     
             except HTTPError as e:
+                print("erreure ici")
                 if e.code != 404:
                     raise
                 # Some adaptive streams need to be requested with sequence numbers
@@ -283,10 +292,10 @@ class Stream:
                     self.url,
                     self._session,
                     timeout=timeout,
-                    max_retries=max_retries
+                    max_retries=max_retries,
                 ):
                     # reduce the (bytes) remainder by the length of the chunk.
-                    bytes_remaining -= len(chunk)
+                    bytes_remaining -= len(chunk) 
                     # send to the on_progress callback.
                     await self.on_progress(chunk, fh, bytes_remaining)
         await self.on_complete(file_path)
@@ -308,11 +317,11 @@ class Stream:
 
     async def exists_at_path(self, file_path: str) -> bool:
         return (
-            os.path.isfile(file_path)
-            and os.path.getsize(file_path) == (await self.filesize)
+            os.path.isfile(file_path) and
+           os.path.getsize(file_path) == (await self.filesize)
         )
 
-    async def stream_to_buffer(self, buffer: BinaryIO) -> None:
+    async def stream_to_buffer(self, buffer: aiof.BinaryFileWrapper) -> None:
         """Write the media stream to buffer
 
         :rtype: io.BytesIO buffer
@@ -324,13 +333,13 @@ class Stream:
 
         async for chunk in request.stream(self.url, self._session):
             # reduce the (bytes) remainder by the length of the chunk.
-            bytes_remaining -= len(chunk)
+            bytes_remaining -= len(chunk) 
             # send to the on_progress callback.
-            await self.on_progress(chunk, buffer, bytes_remaining)
+            await self.on_progress(chunk, buffer, bytes_remaining,)
         await self.on_complete(None)
 
     async def on_progress(
-        self, chunk: bytes, file_handler:BinaryIO, bytes_remaining: int
+        self, chunk: bytes, file_handler:aiof.BinaryFileWrapper, bytes_remaining: int, 
     ):
         """On progress callback function.
 
@@ -351,12 +360,11 @@ class Stream:
         :rtype: None
 
         """
-        
-        async with aiof.async_open(file_handler.name, mode="ab+") as fp:
-            await fp.write(chunk)
-            logger.debug("download remaining: %s", bytes_remaining)
-            if self._monostate.on_progress:
-                await self._monostate.on_progress(self, chunk, bytes_remaining)
+        # file_handler.seek(os.SEEK_END)
+        await file_handler.write(chunk)
+        logger.debug("download remaining: %s", bytes_remaining)
+        if self._monostate.on_progress:
+            await self._monostate.on_progress(self, chunk, bytes_remaining)
 
     async def on_complete(self, file_path: Optional[str]):
         """On download complete handler function.

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -259,7 +259,7 @@ class Stream:
         bytes_remaining = (await self.filesize)
         logger.debug(f'downloading ({(await self.filesize)} total bytes) file to {file_path}')
         # async_open allow us to open and write on many files concurently
-        async with aiof.async_open(file_path, "ab+") as fh:
+        with open(file_path, "ab+") as fh:
             """ 'current_downloaded' help us to indicate to the server that we have already downloaded part of the file and  we just want to continue downloading from there
             """ 
             current_downloaded = fh.tell() # since we are opening file with 'ab' mode file_handler will give filesize in bytes

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -17,9 +17,6 @@ from urllib.error import HTTPError
 from urllib.parse import parse_qs
 from aiohttp import ClientSession
 from async_property import async_property
-# import aiofiles as aiofs
-import aiofile as aiof
-# from aiofiles.threadpool.binary import AsyncFileIO
 from pytube import extract
 from pytube import request
 from pytube.helpers import safe_filename
@@ -338,8 +335,8 @@ class Stream:
             await self.on_progress(chunk, buffer, bytes_remaining,)
         await self.on_complete(None)
 
-    async def on_progress(
-        self, chunk: bytes, file_handler:aiof.BinaryFileWrapper, bytes_remaining: int, 
+    def on_progress(
+        self, chunk: bytes, file_handler: BinaryIO, bytes_remaining: int
     ):
         """On progress callback function.
 
@@ -360,11 +357,10 @@ class Stream:
         :rtype: None
 
         """
-        # file_handler.seek(os.SEEK_END)
-        await file_handler.write(chunk)
+        file_handler.write(chunk)
         logger.debug("download remaining: %s", bytes_remaining)
         if self._monostate.on_progress:
-            await self._monostate.on_progress(self, chunk, bytes_remaining)
+            self._monostate.on_progress(self, chunk, bytes_remaining)
 
     async def on_complete(self, file_path: Optional[str]):
         """On download complete handler function.

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -335,7 +335,7 @@ class Stream:
             await self.on_progress(chunk, buffer, bytes_remaining,)
         await self.on_complete(None)
 
-    def on_progress(
+    async def on_progress(
         self, chunk: bytes, file_handler: BinaryIO, bytes_remaining: int
     ):
         """On progress callback function.
@@ -360,7 +360,7 @@ class Stream:
         file_handler.write(chunk)
         logger.debug("download remaining: %s", bytes_remaining)
         if self._monostate.on_progress:
-            self._monostate.on_progress(self, chunk, bytes_remaining)
+            await self._monostate.on_progress(self, chunk, bytes_remaining)
 
     async def on_complete(self, file_path: Optional[str]):
         """On download complete handler function.

--- a/pytube/streams.py
+++ b/pytube/streams.py
@@ -318,7 +318,7 @@ class Stream:
            os.path.getsize(file_path) == (await self.filesize)
         )
 
-    async def stream_to_buffer(self, buffer: aiof.BinaryFileWrapper) -> None:
+    async def stream_to_buffer(self, buffer:BinaryIO) -> None:
         """Write the media stream to buffer
 
         :rtype: io.BytesIO buffer


### PR DESCRIPTION
I'm a bit annoying  when I need to restart the download process from the 0 each time time a stream fails to download before the end. Its could be great if  I can resume  where we left and restart to dl at this point instead  of restart 

That is the feature that I want to see in pytube_async. Last time you said me that aio buffer is not important cause write will be always  sync then I have removed so on_progresse will no longer a couroutine and will comme back to a simple func. 